### PR TITLE
prepend fullImagePath with nextcloud path

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -136,7 +136,7 @@ module.exports = NodeHelper.create({
                         "Authorization": "Basic " + new Buffer.from(self.config.repositoryConfig.username + ":" + self.config.repositoryConfig.password).toString("base64")
                     }
                 };
-                https.get(fullImagePath, requestOptions, (response) => {
+                https.get(self.config.repositoryConfig.path + fullImagePath, requestOptions, (response) => {
                     response.setEncoding('base64');
                     var fileEncoded = "data:" + response.headers["content-type"] + ";base64,";
                     response.on("data", (data) => { fileEncoded += data; });


### PR DESCRIPTION
### Problem I stumbled upon:

I had troubles getting MMM-RandomPhtoto to work with my Nextcloud share.
In the logs, I read the message "Invalid URL", and no matter what kind of WebDAV URL I used, it didn't work.

I took a look at the code, and found this:

### Solution in this PR:

node_helper calls the http get with the fullImagePath, which, at this point, consists of only the fileName and extension.
I prepended the configured nextcloud Path, and with this change, I finally had images appearing on my Magic Mirror!

Thanks for this cool module!