### PR TITLE
added basic filtering for video files

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -94,15 +94,18 @@ module.exports = NodeHelper.create({
                 body += data;
             });
             response.on("end", function() {
+                var filteredImageList = [];
                 imageList = body.match(/href>\/[^<]+/g);
                 imageList.shift(); // delete first array entry, because it contains the link to the current folder
                 if (imageList && imageList.length > 0) {
                     imageList.forEach(function(item, index) {
-                        // remove clutter and the pathing from the entry -> only save file name
-                        imageList[index] = item.replace("href>" + urlParts.pathname, "");
-                        //console.log("[" + self.name + "] Found entry: " + imageList[index]);
+                        //filter video files
+                        if (!item.endsWith('.mp4')) {
+                            // remove clutter and the pathing from the entry -> only save file name
+                            filteredImageList.push(item.replace("href>" + urlParts.pathname, ""));
+                        }
                     });
-                    self.sendSocketNotification("IMAGE_LIST", imageList);
+                    self.sendSocketNotification("IMAGE_LIST", filteredImageList);
                     return;
                 } else {
                     console.log("[" + this.name + "] WARNING: did not get any images from nextcloud url");


### PR DESCRIPTION
### Problem
I noticed my MagicMirror black screening randomly. In the logs, I noticed an exception from the RandomPhoto module, with the error message of "invalid string length". After some debugging, I found that shortly before the error, RandomPhoto tried to download video files. In my case, I have the repositorySource pointed to a Nextcloud directory containing both photos and videos.

### My solution
I added some super basic filtering to remove any mp4 files from the imageList

### Future ToDos
At the moment, i only filtered for mp4s, but of course it would be best to filter all videos.
I see three possibillites:

1. Adding all kinds of video file extensions to the code to filter (not comprehensive and cluttering the code, possibly slow as well)
2. Adjusting the regex in line 97/98 to look for contentType
   - Nextclouds response body includes details about the files such as the contentType. Filtering here would be great, since it would catch all video files (or better, using it inclusivley to only allow image files). The problem here is that nextcloud includes the directory itself in the response body, I was not able to write a sleek regex for this so far.

3. Adjusting the regex to look for fileSize
   - Looking at and filtering based on the fileSize property might also be an option, if the module might support displaying videos in the future. This would also catch huge image files.