### PR TITLE
fix: migrate express route parameter to v5

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -13,7 +13,7 @@ module.exports = NodeHelper.create({
         this.localdirectory = false;
 
         this.imageList = [];
-        this.expressApp.get("/" + this.name + "/images/:randomImageName(*)", async function(request, response) {
+        this.expressApp.get("/" + this.name + "/images/:randomImageName", async function(request, response) {
             var imageBase64Encoded = await self.fetchEncodedImage(request.params.randomImageName);
             response.send(imageBase64Encoded);
         });


### PR DESCRIPTION
This PR fixes compatibility with mm² `v2.32.0`, as it switched to express v5.

closes: #15 