### PR TITLE
add regex exclude function for localdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/MMM-RandomPhoto.js
+++ b/MMM-RandomPhoto.js
@@ -26,7 +26,7 @@ Module.register("MMM-RandomPhoto",{
             username: "",
             password: "",
             recursive: false,
-			exclude: [],
+            exclude: [],
         },
         width: 1920,
         height: 1080,

--- a/MMM-RandomPhoto.js
+++ b/MMM-RandomPhoto.js
@@ -26,6 +26,7 @@ Module.register("MMM-RandomPhoto",{
             username: "",
             password: "",
             recursive: false,
+			exclude: [],
         },
         width: 1920,
         height: 1080,
@@ -107,7 +108,7 @@ Module.register("MMM-RandomPhoto",{
         if (self.localdirectory || self.nextcloud) {
             if (self.imageList && self.imageList.length > 0) {
                 url = "/" + this.name + "/images/" + this.returnImageFromList(mode);
-                
+
                 jQuery.ajax({
                     method: "GET",
                     url: url,

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options for `repositoryConfig` - [more information](https://github.com/skuethe/M
 | `username`            | *Required for nextcloud with basic auth* - The username if images require basic authentication.<br><br>**Type:** `string`<br>**Default:** ``
 | `password`            | *Required for nextcloud with basic auth* - The password if images require basic authentication.<br><br>**Type:** `string`<br>**Default:** ``
 | `recursive`           | *Optional for localdirectory* - Search recursive for images in path.<br><br>**Type:** `boolean`<br>**Default:** `false`
+| `exclude`           | *Optional for localdirectory* - Exclude matching regex files.<br><br>**Type:** `list`<br>**Default:** `[]`
 
 Here are some examples for entries in `config.js`
 
@@ -108,6 +109,7 @@ Here are some examples for entries in `config.js`
         repositoryConfig: {
             path: "/home/USER/pictures/background/",
             recursive: true,
+            exclude: ["tmp", "#recycle"],
         },
     }
 },

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,6 +1,7 @@
 require("url"); // for nextcloud
 const https = require("node:https"); // for nextcloud
 const fs = require("fs"); // for localdirectory
+const Log = require("logger");
 
 const NodeHelper = require("node_helper");
 
@@ -49,14 +50,18 @@ module.exports = NodeHelper.create({
             return false;
         }
 
+	const excludePattern = self.config.repositoryConfig.exclude?.map(pattern => new RegExp(pattern));
+
         var fileList = fs.readdirSync(path, { withFileTypes: true });
         if (fileList.length > 0) {
             for (var f = 0; f < fileList.length; f++) {
+		if (excludePattern?.some(regex => regex.test(fileList[f].name))) continue;
+
                 if (fileList[f].isFile()) {
                     //TODO: add mime type check here
                     self.imageList.push(encodeURIComponent(path + "/" + fileList[f].name));
                 }
-                if ((self.config.repositoryConfig.recursive === true) && fileList[f].isDirectory()) {		
+                if ((self.config.repositoryConfig.recursive === true) && fileList[f].isDirectory()) {
                     self.fetchLocalImageDirectory(path + "/" + fileList[f].name);
                 }
             }


### PR DESCRIPTION
- Added regex filters to skip unwanted files/folders (e.g., #recycle, @eaDir, .DS_Store, .heic)
- Improves performance and avoids loading irrelevant data
- Tested with Synology NTFS mount
